### PR TITLE
Redact Authors

### DIFF
--- a/data/messages.jsonl
+++ b/data/messages.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f111e8d9a57fc5efae64c88e6b027e5cd5c460c69d8e36e9c701300e17bed4db
-size 46811968
+oid sha256:37ed4a81b2b6c2feae82b26834197a7f9137d088130d4ee7abed757873dbea62
+size 46723629

--- a/data/messages.jsonl
+++ b/data/messages.jsonl
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:82e12fcb400cb88efb0b389c81057f7450493f315645ec5ba4145f28f1dbe7d3
-size 47308100
+oid sha256:f111e8d9a57fc5efae64c88e6b027e5cd5c460c69d8e36e9c701300e17bed4db
+size 46811968

--- a/examples/example_message_filtering.py
+++ b/examples/example_message_filtering.py
@@ -29,7 +29,7 @@ def example_message_filtering(message_db: MessageDB):
 
     # EXAMPLE 2
     # Load practice logs of a certain user
-    author_id = "Linda ”Polly Ester” Ö"
+    author_id = "curious-frame"
     practice_logs = (
         message_db.filter_categories(categories={DhOCategory.PracticeLogs})
         .filter_threads(authors={author_id})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ typer = "^0.7.0"
 pre-commit = "^3.0.1"
 nltk = "^3.8.1"
 sklearn-sfa = "^0.1.6"
+codenamize = "^1.2.3"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.2.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dho-scrapy"
-version = "0.3.0"
+version = "0.4.0"
 description = ""
 authors = ["Björn <bjoernwe@users.noreply.github.com>"]
 readme = "README.md"

--- a/scraper/dho_scraper/pipelines.py
+++ b/scraper/dho_scraper/pipelines.py
@@ -67,9 +67,15 @@ class RemoveDhOBlockquotesPipeline:
 
     @staticmethod
     def _remove_blockquotes(html: str) -> str:
+
         soup = BeautifulSoup(html, "html.parser")
+
+        for tag in soup.findAll("div", class_="quote-title"):
+            tag.decompose()
+
         for tag in soup.findAll("div", class_="quote"):
             tag.decompose()
+
         return str(soup)
 
 

--- a/scraper/dho_scraper/pipelines.py
+++ b/scraper/dho_scraper/pipelines.py
@@ -3,6 +3,7 @@
 # Don't forget to add your pipeline to the ITEM_PIPELINES setting
 # See: https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 from bs4 import BeautifulSoup
+from codenamize import codenamize
 from itemadapter import ItemAdapter
 from scrapy.exceptions import DropItem
 
@@ -21,6 +22,13 @@ class RemoveDuplicatesPipeline:
             raise DropItem(f"Duplicate item found: {item!r}")
 
         self.ids_seen.add(msg_id)
+        return item
+
+
+class RedactUserPipeline:
+    @staticmethod
+    def process_item(item: DhOMessage, _=None):
+        item.author = codenamize(item.author)
         return item
 
 

--- a/scraper/dho_scraper/settings.py
+++ b/scraper/dho_scraper/settings.py
@@ -67,6 +67,7 @@ ROBOTSTXT_OBEY = True
 # See https://docs.scrapy.org/en/latest/topics/item-pipeline.html
 ITEM_PIPELINES = {
     "dho_scraper.pipelines.RemoveDuplicatesPipeline": 10,
+    "dho_scraper.pipelines.RedactUserPipeline": 100,
     #'dho_scraper.pipelines.RemoveNonOpRepliesPipeline': 100,
     #'dho_scraper.pipelines.RemoveAllRepliesPipeline': 200,
     "dho_scraper.pipelines.RemoveDhOBlockquotesPipeline": 400,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def dho_msg() -> DhOMessage:
         category=DhOCategory.ContemporaryBuddhism,
         thread_id=15662491,
         title="10 things you disagree with Classical Buddhism",
-        author="A. Dietrich Ringle",
+        author="material-size",
         date=datetime(2019, 9, 14, 8, 13, 24),
         msg="Lists are handy things, and in this case they line up with brain wave function.<br /><br />I&#39;ll be surprised.",
         is_first_in_thread=False,

--- a/tests/dho_scraper/test_dho_spider.py
+++ b/tests/dho_scraper/test_dho_spider.py
@@ -75,3 +75,13 @@ def test_feed_output_contains_uri_scheme():
     feed_files: List[str] = list(spider.custom_settings["FEEDS"].keys())
     assert len(feed_files) == 1
     assert feed_files[0].startswith("file://")
+
+
+def test_crawled_messages_are_redacted(crawled_messages: List[DhOMessage]):
+
+    # GIVEN a list of messages crawled by the spider
+    # WHEN all authors are collected
+    authors = {msg.author for msg in crawled_messages}
+
+    # THEN it contains redacted versions of known author names
+    assert "materialistic-gift" in authors

--- a/tests/dho_scraper/test_pipelines.py
+++ b/tests/dho_scraper/test_pipelines.py
@@ -71,7 +71,9 @@ def test_duplicate_spaces_are_removed_from_message():
     argnames=["msg", "min_words", "too_short"],
     argvalues=[("foo", 2, True), ("foo bar", 2, False)],
 )
-def test_(msg: str, min_words: int, too_short: bool):
+def test_messages_can_be_filtered_for_number_of_words(
+    msg: str, min_words: int, too_short: bool
+):
 
     # GIVEN a message and a min number of words
     # WHEN the message is filtered for length

--- a/tests/dho_scraper/test_pipelines.py
+++ b/tests/dho_scraper/test_pipelines.py
@@ -9,7 +9,20 @@ from scraper.dho_scraper.pipelines import RemoveShortMessagePipeline
 from scraper.dho_scraper.pipelines import ReplaceNonStandardWhitespacesPipeline
 
 
-def test_dho_blockquotes_are_removed():
+def test_dho_blockquote_title_tags_are_removed():
+
+    # GIVEN some HTML with DhO-style block quote title tag
+    html = '<div class="quote-title other">TITLE</div>OTHER TEXT'
+
+    # WHEN the HTML is filtered
+    filtered = RemoveDhOBlockquotesPipeline._remove_blockquotes(html)
+
+    # THEN the result does not contain quote title anymore (but other text)
+    assert "OTHER TEXT" in filtered
+    assert "TITLE" not in filtered
+
+
+def test_dho_blockquote_tags_are_removed():
 
     # GIVEN some HTML with DhO-style block quote tag
     html = '<div class="quote other">A QUOTE</div>OTHER TEXT'

--- a/tests/dho_scraper/test_pipelines.py
+++ b/tests/dho_scraper/test_pipelines.py
@@ -2,6 +2,7 @@ import pytest
 
 from data_models.dho_message import DhOMessage
 from scraper.dho_scraper.pipelines import HtmlToTextPipeline
+from scraper.dho_scraper.pipelines import RedactUserPipeline
 from scraper.dho_scraper.pipelines import RemoveDhOBlockquotesPipeline
 from scraper.dho_scraper.pipelines import RemoveDuplicateSpacesPipeline
 from scraper.dho_scraper.pipelines import RemoveShortMessagePipeline
@@ -83,3 +84,17 @@ def test_messages_can_be_filtered_for_number_of_words(
 
     # THEN it is filtered as expected
     assert is_msg_too_short == too_short
+
+
+def test_user_name_can_be_redacted(dho_msg: DhOMessage):
+
+    # GIVEN a RedactUserPipeline
+    redact_pipeline = RedactUserPipeline()
+
+    # WHEN a message is processed
+    dho_msg.author = "TEST AUTHOR"
+    processed_msg = redact_pipeline.process_item(item=dho_msg.copy())
+
+    # THEN the author has been redacted
+    assert processed_msg.author != dho_msg.author
+    assert processed_msg.author == "squalid-big"

--- a/tests/message_db/test_message_db.py
+++ b/tests/message_db/test_message_db.py
@@ -70,7 +70,7 @@ def test_messages_are_grouped_by_author(message_db: MessageDB):
     author_msgs = message_db.group_by_author()
 
     # THEN there are messages of at least one of the known authors
-    assert len(author_msgs["J W"]) >= 7
+    assert len(author_msgs["loving-tone"]) >= 77
 
 
 def test_author_grouping_contains_all_messages(dho_msg: DhOMessage):


### PR DESCRIPTION
Changes:

- Redact author names through `codenamize` library
- Remove block quotes including author name

Limitations:
- Of course, the actual author name can easily be recovered since the original data is public