### PR TITLE
Generic Message Format

### DIFF
--- a/data_tools/dho_message.py
+++ b/data_tools/dho_message.py
@@ -5,7 +5,6 @@ import nltk
 from pydantic import BaseModel
 from pydantic import validator
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.textsnippet import TextSnippet
 
 
@@ -15,7 +14,7 @@ class DhOMessage(BaseModel):
     thread_id: int
     date: datetime
     is_first_in_thread: bool
-    category: DhOCategory
+    category: str
     author: str
     title: str
     msg: str

--- a/data_tools/dho_message.py
+++ b/data_tools/dho_message.py
@@ -8,7 +8,7 @@ from pydantic import validator
 from data_tools.textsnippet import TextSnippet
 
 
-class DhOMessage(BaseModel):
+class ForumMessage(BaseModel):
 
     msg_id: int
     thread_id: int

--- a/data_tools/embedders/embedder.py
+++ b/data_tools/embedders/embedder.py
@@ -3,7 +3,7 @@ import shelve
 from abc import ABC
 from abc import abstractmethod
 from pathlib import Path
-from typing import Iterator
+from typing import Iterable
 from typing import Optional
 
 import numpy as np
@@ -40,7 +40,7 @@ class Embedder(ABC):
 
             return embedding
 
-    def get_embeddings(self, texts: Iterator[str]) -> np.ndarray:
+    def get_embeddings(self, texts: Iterable[str]) -> np.ndarray:
 
         embeddings = []
 

--- a/data_tools/message_db.py
+++ b/data_tools/message_db.py
@@ -11,7 +11,7 @@ from typing import Union
 
 from tqdm import tqdm
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from data_tools.msg_category import MsgCategory
 from data_tools.textsnippet import TextSnippet
 
@@ -23,8 +23,8 @@ class MessageDB:
     thread, etc.
     """
 
-    def __init__(self, msgs: List[DhOMessage]):
-        self._msgs: Dict[int, DhOMessage] = {msg.msg_id: msg for msg in msgs}
+    def __init__(self, msgs: List[ForumMessage]):
+        self._msgs: Dict[int, ForumMessage] = {msg.msg_id: msg for msg in msgs}
         assert len(self._msgs) == len(
             msgs
         ), "Message lists seem to contain duplicate IDs"
@@ -36,7 +36,7 @@ class MessageDB:
 
         with open(jsonl_path, "r") as f:
             for line in tqdm(f.readlines()):
-                msg = DhOMessage.parse_raw(line)
+                msg = ForumMessage.parse_raw(line)
                 msgs.append(msg)
 
         return cls(msgs=msgs)
@@ -47,10 +47,10 @@ class MessageDB:
     def __getitem__(self, item):
         return self._msgs[item]
 
-    def get_all_messages(self) -> List[DhOMessage]:
+    def get_all_messages(self) -> List[ForumMessage]:
         return list(self._msgs.values())
 
-    def get_first_message(self) -> DhOMessage:
+    def get_first_message(self) -> ForumMessage:
         return self.get_all_messages()[0]
 
     def get_all_message_bodies(self) -> List[str]:
@@ -62,7 +62,7 @@ class MessageDB:
 
     def _group_messages(
         self,
-        key: Callable[[DhOMessage], Any],
+        key: Callable[[ForumMessage], Any],
         keep_keys: Optional[Set[Hashable]] = None,
         min_group_size: int = 1,
     ) -> Dict[Union[int, str], "MessageDB"]:

--- a/data_tools/message_db.py
+++ b/data_tools/message_db.py
@@ -11,8 +11,8 @@ from typing import Union
 
 from tqdm import tqdm
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.dho_message import DhOMessage
+from data_tools.msg_category import MsgCategory
 from data_tools.textsnippet import TextSnippet
 
 
@@ -147,7 +147,7 @@ class MessageDB:
         return MessageDB(msgs=filtered_msgs)
 
     def filter_categories(
-        self, categories: Optional[Set[DhOCategory]] = None, min_num_message: int = 1
+        self, categories: Optional[Set[MsgCategory]] = None, min_num_message: int = 1
     ) -> "MessageDB":
         category_msgs = self.group_by_category(
             keep_categories=categories, min_num_messages=min_num_message

--- a/data_tools/msg_category.py
+++ b/data_tools/msg_category.py
@@ -1,0 +1,5 @@
+from enum import Enum
+
+
+class MsgCategory(str, Enum):
+    pass

--- a/examples/example_message_filtering.py
+++ b/examples/example_message_filtering.py
@@ -1,6 +1,6 @@
 from data_tools.default_paths import default_jsonl_path
-from data_tools.dho_categories import DhOCategory
 from data_tools.message_db import MessageDB
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/experiments/bjoern/experiment_count_practice_logs.py
+++ b/experiments/bjoern/experiment_count_practice_logs.py
@@ -1,6 +1,6 @@
 from data_tools.default_paths import default_jsonl_path
-from data_tools.dho_categories import DhOCategory
 from data_tools.message_db import MessageDB
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/experiments/bjoern/experiment_labeling_text.py
+++ b/experiments/bjoern/experiment_labeling_text.py
@@ -1,8 +1,8 @@
 import pandas as pd
 
 from data_tools.default_paths import default_jsonl_path
-from data_tools.dho_categories import DhOCategory
 from data_tools.message_db import MessageDB
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/experiments/bjoern/experiment_model_comparison.py
+++ b/experiments/bjoern/experiment_model_comparison.py
@@ -6,8 +6,8 @@ import pandas as pd
 import plotly.express as px
 from sklearn.decomposition import PCA
 
-from data_tools.dho_categories import DhOCategory
 from experiments.experiment_setup import ExperimentSetup
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/experiments/bjoern/experiment_pca.py
+++ b/experiments/bjoern/experiment_pca.py
@@ -9,9 +9,9 @@ from pandas import DataFrame
 from plotly.subplots import make_subplots
 from sklearn.decomposition import PCA
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.textsnippet import TextSnippet
 from experiments.experiment_setup import ExperimentSetup
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/experiments/bjoern/experiment_sfa.py
+++ b/experiments/bjoern/experiment_sfa.py
@@ -5,8 +5,8 @@ import plotly.express as px
 from sklearn.decomposition import PCA
 from sksfa import SFA
 
-from data_tools.dho_categories import DhOCategory
 from experiments.experiment_setup import ExperimentSetup
+from scraper.dho_scraper.categories import DhOCategory
 
 
 def main():

--- a/scraper/1_crawl_messages.py
+++ b/scraper/1_crawl_messages.py
@@ -6,7 +6,7 @@ import typer
 from scrapy.crawler import CrawlerProcess
 from scrapy.utils.project import get_project_settings
 
-from data_tools.dho_categories import DhOCategory
+from scraper.dho_scraper.categories import DhOCategory
 from scraper.dho_scraper.spider import DhOSpider
 
 

--- a/scraper/dho_scraper/categories.py
+++ b/scraper/dho_scraper/categories.py
@@ -1,7 +1,7 @@
-from enum import Enum
+from data_tools.msg_category import MsgCategory
 
 
-class DhOCategory(str, Enum):
+class DhOCategory(MsgCategory):
     ContemporaryBuddhism = (
         "https://www.dharmaoverground.org/discussion/-/message_boards/category/13969849"
     )

--- a/scraper/dho_scraper/pipelines.py
+++ b/scraper/dho_scraper/pipelines.py
@@ -7,14 +7,14 @@ from codenamize import codenamize
 from itemadapter import ItemAdapter
 from scrapy.exceptions import DropItem
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 
 
 class RemoveDuplicatesPipeline:
     def __init__(self):
         self.ids_seen = set()
 
-    def process_item(self, item: DhOMessage, _):
+    def process_item(self, item: ForumMessage, _):
 
         msg_id = item.msg_id
 
@@ -27,7 +27,7 @@ class RemoveDuplicatesPipeline:
 
 class RedactUserPipeline:
     @staticmethod
-    def process_item(item: DhOMessage, _=None):
+    def process_item(item: ForumMessage, _=None):
         item.author = codenamize(item.author)
         return item
 
@@ -37,7 +37,7 @@ class RemoveNonOpRepliesPipeline:
     thread_owners = {}
 
     @classmethod
-    def process_item(cls, item: DhOMessage, _):
+    def process_item(cls, item: ForumMessage, _):
 
         if item.is_first_in_thread:
             cls.thread_owners[item.thread_id] = item.author  # remember author
@@ -53,7 +53,7 @@ class RemoveNonOpRepliesPipeline:
 
 class RemoveAllRepliesPipeline:
     @classmethod
-    def process_item(cls, item: DhOMessage, _):
+    def process_item(cls, item: ForumMessage, _):
         if item.is_first_in_thread:
             return item
         raise DropItem
@@ -131,7 +131,7 @@ class RemoveShortMessagePipeline:
     def __init__(self, min_message_words: int = 1):
         self._min_message_words = min_message_words
 
-    def process_item(self, item: DhOMessage, _):
+    def process_item(self, item: ForumMessage, _):
         if self._is_too_short(msg=item.msg, min_words=self._min_message_words):
             raise DropItem
         return item

--- a/scraper/dho_scraper/spider.py
+++ b/scraper/dho_scraper/spider.py
@@ -8,8 +8,8 @@ from scrapy.exceptions import CloseSpider
 from scrapy.http import HtmlResponse
 from scrapy.http import XmlResponse
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.dho_message import DhOMessage
+from scraper.dho_scraper.categories import DhOCategory
 
 
 class DhOSpider(scrapy.Spider):

--- a/scraper/dho_scraper/spider.py
+++ b/scraper/dho_scraper/spider.py
@@ -8,7 +8,7 @@ from scrapy.exceptions import CloseSpider
 from scrapy.http import HtmlResponse
 from scrapy.http import XmlResponse
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from scraper.dho_scraper.categories import DhOCategory
 
 
@@ -57,10 +57,10 @@ class DhOSpider(scrapy.Spider):
 
 def _get_messages_from_rss(
     response: XmlResponse, category: DhOCategory
-) -> List[DhOMessage]:
+) -> List[ForumMessage]:
     for i, item in enumerate(reversed(response.xpath("//item"))):
         item.register_namespace("dc", "http://purl.org/dc/elements/1.1/")
-        message = DhOMessage(
+        message = ForumMessage(
             msg_id=item.xpath("./link/text()").get().split("=")[-1],
             category=category,
             thread_id=response.xpath("./channel/link/text()").get().split("=")[-1],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,15 +9,15 @@ from scrapy.crawler import CrawlerProcess
 from scrapy.settings import Settings
 from scrapy.utils.project import get_project_settings
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from data_tools.message_db import MessageDB
 from scraper.dho_scraper.categories import DhOCategory
 from scraper.dho_scraper.spider import DhOSpider
 
 
 @pytest.fixture
-def dho_msg() -> DhOMessage:
-    return DhOMessage(
+def dho_msg() -> ForumMessage:
+    return ForumMessage(
         msg_id=15662490,
         category=DhOCategory.ContemporaryBuddhism,
         thread_id=15662491,
@@ -71,17 +71,17 @@ def message_db(jsonl_path: Path) -> MessageDB:
 
 
 @pytest.fixture(scope="session")
-def crawled_messages(jsonl_path: Path) -> List[DhOMessage]:
+def crawled_messages(jsonl_path: Path) -> List[ForumMessage]:
     return _messages_from_file(jsonl_path)
 
 
-def _messages_from_file(jsonl_path: Path) -> List[DhOMessage]:
+def _messages_from_file(jsonl_path: Path) -> List[ForumMessage]:
 
     messages = []
 
     with open(str(jsonl_path), "r") as file:
         for line in file.readlines():
-            dho_message = DhOMessage.parse_raw(line)
+            dho_message = ForumMessage.parse_raw(line)
             messages.append(dho_message)
 
     return messages

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,9 +9,9 @@ from scrapy.crawler import CrawlerProcess
 from scrapy.settings import Settings
 from scrapy.utils.project import get_project_settings
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.dho_message import DhOMessage
 from data_tools.message_db import MessageDB
+from scraper.dho_scraper.categories import DhOCategory
 from scraper.dho_scraper.spider import DhOSpider
 
 

--- a/tests/data_tools/test_dho_message.py
+++ b/tests/data_tools/test_dho_message.py
@@ -2,10 +2,10 @@ from datetime import datetime
 
 import pytest
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 
 
-def test_dho_message_accepts_datetime(dho_msg: DhOMessage):
+def test_dho_message_accepts_datetime(dho_msg: ForumMessage):
 
     # GIVEN messsage parameters with date as datetime
     date = datetime(2020, 11, 21, 4, 14, 6)
@@ -13,13 +13,13 @@ def test_dho_message_accepts_datetime(dho_msg: DhOMessage):
     msg_dict["date"] = date
 
     # WHEN a DhO message is created
-    msg = DhOMessage.parse_obj(msg_dict)
+    msg = ForumMessage.parse_obj(msg_dict)
 
     # THEN the date was not changed
     assert msg.date == date
 
 
-def test_dho_message_accepts_date_string_in_dho_format(dho_msg: DhOMessage):
+def test_dho_message_accepts_date_string_in_dho_format(dho_msg: ForumMessage):
 
     # GIVEN messsage parameters with date as string
     date = "Sat, 21 Nov 2020 04:14:06 GMT"
@@ -27,13 +27,13 @@ def test_dho_message_accepts_date_string_in_dho_format(dho_msg: DhOMessage):
     msg_dict["date"] = date
 
     # WHEN a message is created with this input format
-    msg = DhOMessage.parse_obj(msg_dict)
+    msg = ForumMessage.parse_obj(msg_dict)
 
     # THEN the resulting message contains the correct date
     assert msg.date == datetime(2020, 11, 21, 4, 14, 6)
 
 
-def test_message_is_split_into_sentences(dho_msg: DhOMessage):
+def test_message_is_split_into_sentences(dho_msg: ForumMessage):
 
     # GIVEN a message that contains several sentences
     dho_msg.msg = "This is sentence 1. This is sentence two. This is another one."
@@ -50,7 +50,7 @@ def test_message_is_split_into_sentences(dho_msg: DhOMessage):
     ]
 
 
-def test_subsequent_sentences_are_concatenated_in_sliding_window(dho_msg: DhOMessage):
+def test_subsequent_sentences_are_concatenated_in_sliding_window(dho_msg: ForumMessage):
 
     # GIVEN a message that contains several sentences
     dho_msg.msg = "This is sentence 1. This is sentence two. This is another one."
@@ -68,7 +68,7 @@ def test_subsequent_sentences_are_concatenated_in_sliding_window(dho_msg: DhOMes
 
 @pytest.mark.parametrize(argnames="window_size", argvalues=[3, 4])
 def test_sentence_windows_work_with_extreme_values(
-    dho_msg: DhOMessage,
+    dho_msg: ForumMessage,
     window_size: int,
 ):
 
@@ -83,7 +83,7 @@ def test_sentence_windows_work_with_extreme_values(
     assert sentences[0].text == dho_msg.msg
 
 
-def test_sentences_can_be_calculated_for_empty_message(dho_msg: DhOMessage):
+def test_sentences_can_be_calculated_for_empty_message(dho_msg: ForumMessage):
 
     # GIVEN a message with empty body
     dho_msg.msg = ""

--- a/tests/data_tools/test_message_db.py
+++ b/tests/data_tools/test_message_db.py
@@ -4,9 +4,9 @@ from typing import List
 
 import pytest
 
-from data_tools.dho_categories import DhOCategory
 from data_tools.dho_message import DhOMessage
 from data_tools.message_db import MessageDB
+from scraper.dho_scraper.categories import DhOCategory
 
 
 @pytest.fixture

--- a/tests/data_tools/test_message_db.py
+++ b/tests/data_tools/test_message_db.py
@@ -4,7 +4,7 @@ from typing import List
 
 import pytest
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from data_tools.message_db import MessageDB
 from scraper.dho_scraper.categories import DhOCategory
 
@@ -15,7 +15,7 @@ def message_db(jsonl_path) -> MessageDB:
 
 
 @pytest.fixture
-def msgs_in_threads(dho_msg: DhOMessage) -> List[DhOMessage]:
+def msgs_in_threads(dho_msg: ForumMessage) -> List[ForumMessage]:
 
     author_1 = "AUTHOR 1"
     author_2 = "AUTHOR 2"
@@ -51,7 +51,7 @@ def msgs_in_threads(dho_msg: DhOMessage) -> List[DhOMessage]:
     return [msg1, msg2, msg3]
 
 
-def test_all_messages_are_returned(jsonl_path, crawled_messages: List[DhOMessage]):
+def test_all_messages_are_returned(jsonl_path, crawled_messages: List[ForumMessage]):
 
     # GIVEN a list of messages
     assert len(crawled_messages) >= 1
@@ -73,7 +73,7 @@ def test_messages_are_grouped_by_author(message_db: MessageDB):
     assert len(author_msgs["loving-tone"]) >= 77
 
 
-def test_author_grouping_contains_all_messages(dho_msg: DhOMessage):
+def test_author_grouping_contains_all_messages(dho_msg: ForumMessage):
 
     # GIVEN a list of messages from two authors
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -88,7 +88,7 @@ def test_author_grouping_contains_all_messages(dho_msg: DhOMessage):
     assert len(author_msgs["AUTHOR_2"]) == 2
 
 
-def test_author_grouping_is_filtered_for_min_num_messages(dho_msg: DhOMessage):
+def test_author_grouping_is_filtered_for_min_num_messages(dho_msg: ForumMessage):
 
     # GIVEN a list of messages from two authors
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -118,7 +118,7 @@ def test_messages_are_sorted_by_date(message_db: MessageDB):
     ]
 
 
-def test_category_grouping_contains_all_messages(dho_msg: DhOMessage):
+def test_category_grouping_contains_all_messages(dho_msg: ForumMessage):
 
     # GIVEN a list of messages in two categories
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -133,7 +133,7 @@ def test_category_grouping_contains_all_messages(dho_msg: DhOMessage):
     assert len(category_msgs["CATEGORY_2"]) == 2
 
 
-def test_category_groups_are_filtered_for_length(dho_msg: DhOMessage):
+def test_category_groups_are_filtered_for_length(dho_msg: ForumMessage):
 
     # GIVEN a list of messages in two categories
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -148,7 +148,7 @@ def test_category_groups_are_filtered_for_length(dho_msg: DhOMessage):
     assert len(category_msgs["CATEGORY_2"]) == 2
 
 
-def test_messages_are_filtered_for_length(dho_msg: DhOMessage):
+def test_messages_are_filtered_for_length(dho_msg: ForumMessage):
 
     # GIVEN messages of different lengths
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(2)]
@@ -165,7 +165,7 @@ def test_messages_are_filtered_for_length(dho_msg: DhOMessage):
     assert filtered_msgs[0].msg == "two plus words"
 
 
-def test_thread_grouping_contains_all_messages(msgs_in_threads: List[DhOMessage]):
+def test_thread_grouping_contains_all_messages(msgs_in_threads: List[ForumMessage]):
 
     # GIVEN a list of messages in two threads
     db = MessageDB(msgs=msgs_in_threads)
@@ -178,7 +178,7 @@ def test_thread_grouping_contains_all_messages(msgs_in_threads: List[DhOMessage]
     assert len(thread[222]) == 2
 
 
-def test_thread_groups_are_filtered_by_size(msgs_in_threads: List[DhOMessage]):
+def test_thread_groups_are_filtered_by_size(msgs_in_threads: List[ForumMessage]):
 
     # GIVEN a list of messages in two threads
     db = MessageDB(msgs=msgs_in_threads)
@@ -217,7 +217,7 @@ def test_non_op_thread_responses_are_filtered_out(message_db: MessageDB):
         assert len(authors_in_thread) == 1
 
 
-def test_authors_are_filtered(dho_msg: DhOMessage):
+def test_authors_are_filtered(dho_msg: ForumMessage):
 
     # GIVEN a list of messages from two authors
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -234,7 +234,7 @@ def test_authors_are_filtered(dho_msg: DhOMessage):
     assert "AUTHOR_1" in author_msgs
 
 
-def test_authors_are_filtered_with_min_message_number(dho_msg: DhOMessage):
+def test_authors_are_filtered_with_min_message_number(dho_msg: ForumMessage):
 
     # GIVEN a list of messages from two authors
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -254,7 +254,7 @@ def test_authors_are_filtered_with_min_message_number(dho_msg: DhOMessage):
     assert filtered_msgs[0].author == filtered_msgs[0].author == "AUTHOR_2"
 
 
-def test_filtering_no_authors_keeps_all_authors(dho_msg: DhOMessage):
+def test_filtering_no_authors_keeps_all_authors(dho_msg: ForumMessage):
 
     # GIVEN a list of messages from two authors
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -273,7 +273,7 @@ def test_filtering_no_authors_keeps_all_authors(dho_msg: DhOMessage):
     argvalues=[lambda m: m.author, lambda m: m.thread_id, lambda m: m.category],
 )
 def test_groups_are_sorted_for_size(
-    message_db: MessageDB, key: Callable[[DhOMessage], Any]
+    message_db: MessageDB, key: Callable[[ForumMessage], Any]
 ):
 
     # GIVEN a DB of messages
@@ -290,7 +290,7 @@ def test_groups_are_sorted_for_size(
     argvalues=[lambda m: m.author, lambda m: m.thread_id, lambda m: m.category],
 )
 def test_groups_are_filtered_for_size(
-    message_db: MessageDB, key: Callable[[DhOMessage], Any]
+    message_db: MessageDB, key: Callable[[ForumMessage], Any]
 ):
 
     # GIVEN a DB of messages
@@ -302,7 +302,7 @@ def test_groups_are_filtered_for_size(
         assert len(group_msgs) >= 5
 
 
-def test_categories_are_filtered(dho_msg: DhOMessage):
+def test_categories_are_filtered(dho_msg: ForumMessage):
 
     # GIVEN a list of messages in two categories
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -318,7 +318,7 @@ def test_categories_are_filtered(dho_msg: DhOMessage):
     assert len(filtered_db) == 2
 
 
-def test_filtering_no_category_keeps_all_categories(dho_msg: DhOMessage):
+def test_filtering_no_category_keeps_all_categories(dho_msg: ForumMessage):
 
     # GIVEN a list of messages in two categories
     msgs = [dho_msg.copy(update={"msg_id": i}) for i in range(3)]
@@ -333,7 +333,7 @@ def test_filtering_no_category_keeps_all_categories(dho_msg: DhOMessage):
 
 
 def test_threads_are_filtered_with_min_message_number(
-    msgs_in_threads: List[DhOMessage],
+    msgs_in_threads: List[ForumMessage],
 ):
 
     # GIVEN a list of messages in two threads
@@ -347,7 +347,7 @@ def test_threads_are_filtered_with_min_message_number(
     assert filtered_msgs[0].thread_id == filtered_msgs[0].thread_id == 222
 
 
-def tests_threads_are_filtered_for_thread_author(msgs_in_threads: List[DhOMessage]):
+def tests_threads_are_filtered_for_thread_author(msgs_in_threads: List[ForumMessage]):
 
     # GIVEN a list of messages in two threads
     db = MessageDB(msgs=msgs_in_threads)
@@ -362,7 +362,7 @@ def tests_threads_are_filtered_for_thread_author(msgs_in_threads: List[DhOMessag
     assert filtered_msgs[1].author == "AUTHOR 1"
 
 
-def test_all_messages_are_split_into_sentences(dho_msg: DhOMessage):
+def test_all_messages_are_split_into_sentences(dho_msg: ForumMessage):
 
     # GIVEN a message DB with two messages
     db = MessageDB(

--- a/tests/dho_scraper/test_dho_parsing.py
+++ b/tests/dho_scraper/test_dho_parsing.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from scrapy.http import XmlResponse
 
-from data_tools.dho_categories import DhOCategory
+from scraper.dho_scraper.categories import DhOCategory
 from scraper.dho_scraper.spider import _get_messages_from_rss
 
 

--- a/tests/dho_scraper/test_dho_spider.py
+++ b/tests/dho_scraper/test_dho_spider.py
@@ -1,24 +1,24 @@
 from pathlib import Path
 from typing import List
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from scraper.dho_scraper.spider import DhOCategory
 from scraper.dho_scraper.spider import DhOSpider
 
 
-def test_spider_finds_expected_number_of_messages(crawled_messages: List[DhOMessage]):
+def test_spider_finds_expected_number_of_messages(crawled_messages: List[ForumMessage]):
     # GIVEN a spider for DhO
     # WHEN the messages are crawled
     # THEN there's the expected number of them
     assert len(crawled_messages) >= 31
 
 
-def _find_msg_by_id(msg_id: int, msgs: List[DhOMessage]) -> DhOMessage:
+def _find_msg_by_id(msg_id: int, msgs: List[ForumMessage]) -> ForumMessage:
     return next(filter(lambda m: m.msg_id == msg_id, msgs))
 
 
 def test_spider_finds_known_message(
-    crawled_messages: List[DhOMessage], dho_msg: DhOMessage
+    crawled_messages: List[ForumMessage], dho_msg: ForumMessage
 ):
     # GIVEN a known message
     # WHEN all messages are crawled by the spider
@@ -28,7 +28,9 @@ def test_spider_finds_known_message(
     assert msg.author == dho_msg.author
 
 
-def test_spider_removes_html(crawled_messages: List[DhOMessage], dho_msg: DhOMessage):
+def test_spider_removes_html(
+    crawled_messages: List[ForumMessage], dho_msg: ForumMessage
+):
 
     # GIVEN a DhO spider and a known message with HTML tags
     assert "<" in dho_msg.msg
@@ -40,7 +42,7 @@ def test_spider_removes_html(crawled_messages: List[DhOMessage], dho_msg: DhOMes
     assert "<" not in msg.msg
 
 
-def test_spider_parses_message_ids(crawled_messages: List[DhOMessage]):
+def test_spider_parses_message_ids(crawled_messages: List[ForumMessage]):
 
     # GIVEN a list of messages crawled by the spider
     # WHEN the message IDs are considered
@@ -51,7 +53,7 @@ def test_spider_parses_message_ids(crawled_messages: List[DhOMessage]):
 
 
 def test_crawled_messages_contain_category(
-    crawled_messages: List[DhOMessage], test_dho_category: DhOCategory
+    crawled_messages: List[ForumMessage], test_dho_category: DhOCategory
 ):
 
     # GIVEN spider and a certain category
@@ -77,7 +79,7 @@ def test_feed_output_contains_uri_scheme():
     assert feed_files[0].startswith("file://")
 
 
-def test_crawled_messages_are_redacted(crawled_messages: List[DhOMessage]):
+def test_crawled_messages_are_redacted(crawled_messages: List[ForumMessage]):
 
     # GIVEN a list of messages crawled by the spider
     # WHEN all authors are collected

--- a/tests/dho_scraper/test_pipelines.py
+++ b/tests/dho_scraper/test_pipelines.py
@@ -1,6 +1,6 @@
 import pytest
 
-from data_tools.dho_message import DhOMessage
+from data_tools.dho_message import ForumMessage
 from scraper.dho_scraper.pipelines import HtmlToTextPipeline
 from scraper.dho_scraper.pipelines import RedactUserPipeline
 from scraper.dho_scraper.pipelines import RemoveDhOBlockquotesPipeline
@@ -35,7 +35,7 @@ def test_dho_blockquote_tags_are_removed():
     assert "A QUOTE" not in filtered
 
 
-def test_html_is_removed_from_message(dho_msg: DhOMessage):
+def test_html_is_removed_from_message(dho_msg: ForumMessage):
 
     # GIVEN a DhO message with HTML tags
     html = dho_msg.msg
@@ -99,7 +99,7 @@ def test_messages_can_be_filtered_for_number_of_words(
     assert is_msg_too_short == too_short
 
 
-def test_user_name_can_be_redacted(dho_msg: DhOMessage):
+def test_user_name_can_be_redacted(dho_msg: ForumMessage):
 
     # GIVEN a RedactUserPipeline
     redact_pipeline = RedactUserPipeline()


### PR DESCRIPTION
The `DhOSpider` used to parse messages into `DhOMessage` format. This message format, however, was intended to be generic. That is, different spiders for different data sources are supposed to generate a unified message format. Thus, the name `DhOMessage` is not appropriate. This PR renames `DhOMessage` to `ForumMessage`.